### PR TITLE
fix compile error on ubuntu 12.04

### DIFF
--- a/resampler.h
+++ b/resampler.h
@@ -1,6 +1,8 @@
 #ifndef RESAMPLER_H
 #define RESAMPLER_H
 
+#include <stdlib.h>
+#include <memory.h>
 #include <node.h>
 #include <node_buffer.h>
 #include <libresample.h>


### PR DESCRIPTION
Add memory.h and stdlib.h for memcpy/free/malloc.
